### PR TITLE
Use `asyncmap` to limit number of tasks

### DIFF
--- a/src/JuliaGPsDocs.jl
+++ b/src/JuliaGPsDocs.jl
@@ -165,7 +165,7 @@ used as part of the `pages` argument to `Documenter.makedocs()`.
 """
 function find_generated_examples(pkg)
     EXAMPLES_OUT = _examples_output_dir(pkgdir(pkg))
-    return map(basename.(filter!(isdir, readdir(EXAMPLES_OUT; join=true)),)) do x
+    return map(basename.(filter!(isdir, readdir(EXAMPLES_OUT; join=true)))) do x
         joinpath("examples", x, "index.md")
     end
 end

--- a/src/JuliaGPsDocs.jl
+++ b/src/JuliaGPsDocs.jl
@@ -86,7 +86,7 @@ function generate_examples(
     @info "Instantiating examples environments"
     precompile_packages(pkg, examples)
 
-    @info """Running examples in $(parallel ? "parallel" : "series")"""
+    @info """Running examples with $(ntasks == 0 ? length(examples) : ntasks) $(ntasks == 1 ? "task" : "parallel tasks")"""
     processes = run_examples(
         examples, EXAMPLES_OUT, examples_basedir, PKG_DIR, WEBSITE, channeled_tasks
     )
@@ -135,7 +135,7 @@ Start background processes to render the examples using the $(LITERATE) script.
 - `examples_basedir`: relative path to the root examples folder
 - `PKG_DIR`: path to the package to be developed
 - `WEBSITE`: path to the website url
-- `parallel`: run examples in parallel
+- `ntasks`: maximum number of tasks for running in parallel
 """
 function run_examples(examples, EXAMPLES_OUT, examples_basedir, PKG_DIR, WEBSITE, ntasks)
     cmd = addenv( # From https://github.com/devmotion/CalibrationErrors.jl/

--- a/src/JuliaGPsDocs.jl
+++ b/src/JuliaGPsDocs.jl
@@ -11,7 +11,7 @@ const LITERATE = joinpath(@__DIR__, "literate.jl")
         website_root::String="https://juliagaussianprocesses.github.io/",
         inclusions::Union{Symbol,AbstractVector{<:String}}=:all,
         exclusions::AbstractVector{<:String}=[],
-        parallel::Bool=true,
+        ntasks::Int=0,
     )
 
 Initialize the environments in each folder `pkgdir(pkg)/examples_basedir` sequentially.
@@ -48,18 +48,18 @@ docs
 - `website_root`: the website root path (for correct redirecting in the examples)
 - `inclusions`: will only run the example directories listed
 - `exclusions`: will not run any of the examples directories listed (even if present in `inclusions`)
-- `parallel` : all examples are run in parallel in multiple processes
+- `ntasks` : maximum number of simultaneous parallel processes, set to 0 for no bounds
 
 The final set of examples run is given by `setdiff(intersect(example, inclusions), exclusions)`.
 
 """
 function generate_examples(
     pkg::Module;
-    examples_basedir="examples",
-    website_root="https://juliagaussianprocesses.github.io/",
+    examples_basedir::AbstractString="examples",
+    website_root::AbstractString="https://juliagaussianprocesses.github.io/",
     inclusions=:all,
     exclusions=String[],
-    parallel=true,
+    ntasks::Int=0,
 )
     PKG_DIR = pkgdir(pkg)
     EXAMPLES_DIR = joinpath(PKG_DIR, examples_basedir)
@@ -87,7 +87,9 @@ function generate_examples(
     precompile_packages(pkg, examples)
 
     @info """Running examples in $(parallel ? "parallel" : "series")"""
-    processes = run_examples(examples, EXAMPLES_OUT, examples_basedir, PKG_DIR, WEBSITE, parallel)
+    processes = run_examples(
+        examples, EXAMPLES_OUT, examples_basedir, PKG_DIR, WEBSITE, channeled_tasks
+    )
 
     if isempty(processes)
         error("no process was run, check the paths used to your examples")
@@ -135,11 +137,12 @@ Start background processes to render the examples using the $(LITERATE) script.
 - `WEBSITE`: path to the website url
 - `parallel`: run examples in parallel
 """
-function run_examples(examples, EXAMPLES_OUT, examples_basedir, PKG_DIR, WEBSITE, parallel)
+function run_examples(examples, EXAMPLES_OUT, examples_basedir, PKG_DIR, WEBSITE, ntasks)
     cmd = addenv( # From https://github.com/devmotion/CalibrationErrors.jl/
-        Base.julia_cmd(), "JULIA_LOAD_PATH" => (Sys.iswindows() ? ";" : ":") * @__DIR__
+        Base.julia_cmd(),
+        "JULIA_LOAD_PATH" => (Sys.iswindows() ? ";" : ":") * @__DIR__,
     )
-    return map(examples) do example
+    return asyncmap(examples; ntasks) do example
         return run(
             pipeline(
                 `$(cmd) --startup-file="no" --project=$(example) $(LITERATE) $(basename(example)) $(examples_basedir) $(PKG_DIR) $(EXAMPLES_OUT) $(WEBSITE)`;
@@ -147,7 +150,7 @@ function run_examples(examples, EXAMPLES_OUT, examples_basedir, PKG_DIR, WEBSITE
                 stdout=devnull,
                 stderr=stderr,
             );
-            wait=!parallel,
+            wait=true,
         )::Base.Process
     end
 end
@@ -162,11 +165,7 @@ used as part of the `pages` argument to `Documenter.makedocs()`.
 """
 function find_generated_examples(pkg)
     EXAMPLES_OUT = _examples_output_dir(pkgdir(pkg))
-    return map(
-        basename.(
-            filter!(isdir, readdir(EXAMPLES_OUT; join=true)),
-        ),
-    ) do x
+    return map(basename.(filter!(isdir, readdir(EXAMPLES_OUT; join=true)),)) do x
         joinpath("examples", x, "index.md")
     end
 end

--- a/src/JuliaGPsDocs.jl
+++ b/src/JuliaGPsDocs.jl
@@ -88,7 +88,7 @@ function generate_examples(
 
     @info """Running examples with $(ntasks == 0 ? length(examples) : ntasks) $(ntasks == 1 ? "task" : "parallel tasks")"""
     processes = run_examples(
-        examples, EXAMPLES_OUT, examples_basedir, PKG_DIR, WEBSITE, channeled_tasks
+        examples, EXAMPLES_OUT, examples_basedir, PKG_DIR, WEBSITE, ntasks
     )
 
     if isempty(processes)


### PR DESCRIPTION
Adresses #17 by introducing a maximum number of tasks.